### PR TITLE
Bumps dependencies to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mkdocs-include-markdown-plugin == 7.1.6
-mkdocs-material == 9.6.11
-mkdocs-monorepo-plugin == 1.1.0
-mkdocstrings[python]== 0.29.1
+mkdocs-include-markdown-plugin == 7.2.0
+mkdocs-material == 9.6.21
+mkdocs-monorepo-plugin == 1.1.2
+mkdocstrings[python]== 0.30.1
 docs/submodules/keystone-api
 docs/submodules/keystone-python-client


### PR DESCRIPTION
Patches CVE-2025-59940 in `mkdocs-include-markdown-plugin` versions < 7.1.8
